### PR TITLE
feat: add an intake ticket/form workflow

### DIFF
--- a/lib/hooks/airtable-record-update.ts
+++ b/lib/hooks/airtable-record-update.ts
@@ -1,0 +1,60 @@
+import { stringifyUrl } from "query-string"
+
+import { AirtableRecordParams } from "../../types"
+
+interface Response<TFields> {
+  /** A function to perform the update and return the updated record */
+  updateRecord: (fields: Partial<TFields>) => Promise<Airtable.Record<TFields>>
+}
+
+/**
+ * A hook that provides function to update and return an Airtable record
+ */
+export const useAirtableRecordUpdate = <TFields>({
+  baseId,
+  tableIdOrName,
+  recordId,
+}: AirtableRecordParams): Response<TFields> => {
+  const url = stringifyUrl(
+    {
+      url: "/api/update-airtable-record",
+      query: { baseId, tableIdOrName, recordId },
+    },
+    {
+      skipNull: true,
+    }
+  )
+
+  return {
+    updateRecord: updater<TFields>(url),
+  }
+}
+
+const updater = <TFields>(url: string) => async (
+  fields: Partial<TFields>
+): Promise<Airtable.Record<TFields>> => {
+  const res = await fetch(url, {
+    method: "POST",
+    body: JSON.stringify(fields),
+  })
+
+  if (!res.ok) {
+    const error = new AirtableRecordUpdateException(
+      "An error occurred while updating the record."
+    )
+    error.details = await res.json()
+    throw error
+  }
+  return res.json()
+}
+
+class AirtableRecordUpdateException {
+  readonly name: string
+  message: string
+  details: unknown
+
+  constructor(message: string) {
+    this.name = "AirtableRecordUpdateException"
+    this.message = message
+  }
+}

--- a/lib/hooks/airtable-record-update.ts
+++ b/lib/hooks/airtable-record-update.ts
@@ -3,12 +3,14 @@ import { stringifyUrl } from "query-string"
 import { AirtableRecordParams } from "../../types"
 
 interface Response<TFields> {
-  /** A function to perform the update and return the updated record */
+  /** A function to perform the update and promise the updated record */
   updateRecord: (fields: Partial<TFields>) => Promise<Airtable.Record<TFields>>
 }
 
 /**
- * A hook that provides function to update and return an Airtable record
+ * A hook that provides a function to update a given Airtable record.
+ *
+ * Returns a promise for the updated record, which can be used with an SWR mutation.
  */
 export const useAirtableRecordUpdate = <TFields>({
   baseId,

--- a/lib/hooks/airtable-record.ts
+++ b/lib/hooks/airtable-record.ts
@@ -1,4 +1,4 @@
-import useSWR from "swr"
+import useSWR, { responseInterface } from "swr"
 import { stringifyUrl } from "query-string"
 
 import { AirtableRecordParams } from "../../types"
@@ -15,10 +15,16 @@ interface Response<TFields> {
 
   /** True if the request has errored */
   isError: boolean
+
+  /** Mutate function, bound to SWR cache key */
+  mutate: responseInterface<
+    Airtable.Record<TFields>,
+    AirtableRecordException
+  >["mutate"]
 }
 
 /**
- * useAirtableRecord will return an Airtable record in its entirety.
+ * An SWR data fetching hook that will return an Airtable record in its entirety.
  *
  * Do not use if you wish to avoid sending some fields over the wire.
  */
@@ -37,13 +43,14 @@ export const useAirtableRecord = <TFields>({
     }
   )
 
-  const { data, error } = useSWR(url, fetcher)
+  const { data, error, mutate } = useSWR(url, fetcher)
 
   return {
     record: data,
     error,
     isLoading: !error && !data,
     isError: !!error,
+    mutate,
   }
 }
 

--- a/lib/hooks/airtable-record.ts
+++ b/lib/hooks/airtable-record.ts
@@ -1,0 +1,71 @@
+import useSWR from "swr"
+import { stringifyUrl } from "query-string"
+
+import { AirtableRecordParams } from "../../types"
+
+interface Response<TFields> {
+  /** The retrieved record */
+  record: Airtable.Record<TFields>
+
+  /** A formatted error object, in case the record could not be retrieved */
+  error: AirtableRecordException
+
+  /** True if the request is still in progress */
+  isLoading: boolean
+
+  /** True if the request has errored */
+  isError: boolean
+}
+
+/**
+ * useAirtableRecord will return an Airtable record in its entirety.
+ *
+ * Do not use if you wish to avoid sending some fields over the wire.
+ */
+export const useAirtableRecord = <TFields>({
+  baseId,
+  tableIdOrName,
+  recordId,
+}: AirtableRecordParams): Response<TFields> => {
+  const url = stringifyUrl(
+    {
+      url: "/api/airtable-record",
+      query: { baseId, tableIdOrName, recordId },
+    },
+    {
+      skipNull: true,
+    }
+  )
+
+  const { data, error } = useSWR(url, fetcher)
+
+  return {
+    record: data,
+    error,
+    isLoading: !error && !data,
+    isError: !!error,
+  }
+}
+
+const fetcher = async (url: string) => {
+  const res = await fetch(url)
+  if (!res.ok) {
+    const error = new AirtableRecordException(
+      "An error occurred while getting the record."
+    )
+    error.details = await res.json()
+    throw error
+  }
+  return res.json()
+}
+
+class AirtableRecordException {
+  readonly name: string
+  message: string
+  details: unknown
+
+  constructor(message: string) {
+    this.name = "AirtableRecordException"
+    this.message = message
+  }
+}

--- a/lib/hooks/index.ts
+++ b/lib/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from "./airtable-record"

--- a/lib/hooks/index.ts
+++ b/lib/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from "./airtable-record"
+export * from "./airtable-record-update"

--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
     "lodash": "^4.17.20",
     "next": "9.5.4",
     "next-auth": "^3.1.0",
+    "query-string": "^6.13.7",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-leaflet": "^2.7",
+    "swr": "^0.3.8",
     "vercel": "^20.1.2"
   },
   "devDependencies": {

--- a/pages/api/airtable-record.ts
+++ b/pages/api/airtable-record.ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next"
+import { getSession } from "next-auth/client"
 
 import { airtable } from "../../lib/airtable"
 import { AirtableRecordParams } from "../../types"
@@ -7,24 +8,30 @@ const records = async (
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<void> => {
-  const {
-    baseId,
-    tableIdOrName,
-    recordId,
-  } = (req.query as unknown) as AirtableRecordParams
+  const session = await getSession({ req })
+  if (session) {
+    const {
+      baseId,
+      tableIdOrName,
+      recordId,
+    } = (req.query as unknown) as AirtableRecordParams
 
-  try {
-    const base: Airtable.Base = airtable.base(
-      baseId || process.env.AIRTABLE_BASE_ID
-    )
-    const record = await base(tableIdOrName as string).find(recordId)
+    try {
+      const base: Airtable.Base = airtable.base(
+        baseId || process.env.AIRTABLE_BASE_ID
+      )
+      const record = await base(tableIdOrName as string).find(recordId)
 
-    res.statusCode = 200
-    res.json(record)
-  } catch (error) {
-    res.statusCode = error.statusCode || 500
-    res.json(error)
+      res.statusCode = 200
+      res.json(record)
+    } catch (error) {
+      res.statusCode = error.statusCode || 500
+      res.json(error)
+    }
+  } else {
+    res.status(401)
   }
+  res.end()
 }
 
 export default records

--- a/pages/api/airtable-record.ts
+++ b/pages/api/airtable-record.ts
@@ -1,0 +1,30 @@
+import { NextApiRequest, NextApiResponse } from "next"
+
+import { airtable } from "../../lib/airtable"
+import { AirtableRecordParams } from "../../types"
+
+const records = async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> => {
+  const {
+    baseId,
+    tableIdOrName,
+    recordId,
+  } = (req.query as unknown) as AirtableRecordParams
+
+  try {
+    const base: Airtable.Base = airtable.base(
+      baseId || process.env.AIRTABLE_BASE_ID
+    )
+    const record = await base(tableIdOrName as string).find(recordId)
+
+    res.statusCode = 200
+    res.json(record)
+  } catch (error) {
+    res.statusCode = error.statusCode || 500
+    res.json(error)
+  }
+}
+
+export default records

--- a/pages/api/update-airtable-record.ts
+++ b/pages/api/update-airtable-record.ts
@@ -16,24 +16,15 @@ const records = async (
       recordId,
     } = (req.query as unknown) as AirtableRecordParams
 
-    console.log({ body: JSON.parse(req.body) })
-    console.log({ method: req.method })
-
     try {
       const base: Airtable.Base = airtable.base(
         baseId || process.env.AIRTABLE_BASE_ID
       )
 
-      //
-
       const response = await base(tableIdOrName).update(
         recordId,
         JSON.parse(req.body)
       )
-
-      console.log("?!?!", response)
-
-      //
 
       res.statusCode = 200
       res.json(response)

--- a/pages/api/update-airtable-record.ts
+++ b/pages/api/update-airtable-record.ts
@@ -1,0 +1,52 @@
+import { NextApiRequest, NextApiResponse } from "next"
+import { getSession } from "next-auth/client"
+
+import { airtable } from "../../lib/airtable"
+import { AirtableRecordParams } from "../../types"
+
+const records = async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> => {
+  const session = await getSession({ req })
+  if (session) {
+    const {
+      baseId,
+      tableIdOrName,
+      recordId,
+    } = (req.query as unknown) as AirtableRecordParams
+
+    console.log({ body: JSON.parse(req.body) })
+    console.log({ method: req.method })
+
+    try {
+      const base: Airtable.Base = airtable.base(
+        baseId || process.env.AIRTABLE_BASE_ID
+      )
+
+      //
+
+      const response = await base(tableIdOrName).update([
+        {
+          id: recordId,
+          fields: JSON.parse(req.body),
+        },
+      ])
+
+      console.log(response)
+
+      //
+
+      res.statusCode = 200
+      res.json(response)
+    } catch (error) {
+      res.statusCode = error.statusCode || 500
+      res.json(error)
+    }
+  } else {
+    res.status(401)
+  }
+  res.end()
+}
+
+export default records

--- a/pages/api/update-airtable-record.ts
+++ b/pages/api/update-airtable-record.ts
@@ -26,14 +26,12 @@ const records = async (
 
       //
 
-      const response = await base(tableIdOrName).update([
-        {
-          id: recordId,
-          fields: JSON.parse(req.body),
-        },
-      ])
+      const response = await base(tableIdOrName).update(
+        recordId,
+        JSON.parse(req.body)
+      )
 
-      console.log(response)
+      console.log("?!?!", response)
 
       //
 

--- a/pages/intake/[id].tsx
+++ b/pages/intake/[id].tsx
@@ -1,0 +1,131 @@
+import React from "react"
+import { useRouter } from "next/router"
+import {
+  Box,
+  Button,
+  Divider,
+  Flex,
+  Heading,
+  Spinner,
+  Text,
+  Textarea,
+} from "@chakra-ui/core"
+
+import { Layout } from "../../components/Layout"
+import { Title } from "../../components/Title"
+import { useAirtableRecord } from "../../lib/hooks"
+
+interface RequesterFields {
+  ID: string
+  Name: string
+  "Has grocery needs": boolean
+  Phone: string
+  Notes: string
+}
+
+const TicketPage: React.FC = () => {
+  const router = useRouter()
+  const { id } = router.query
+
+  const { record, error, isLoading, isError } = useAirtableRecord<
+    RequesterFields
+  >({
+    tableIdOrName: "Requesters",
+    recordId: id as string,
+  })
+
+  if (isError)
+    return (
+      <Layout>
+        <Title>Error</Title>
+        <Text>{error.message}</Text>
+        <Text fontFamily="monospace" my="1em" p="1em" bg="#ff000011">
+          <pre>{JSON.stringify(error.details, null, 2)}</pre>
+        </Text>
+      </Layout>
+    )
+
+  if (isLoading)
+    return (
+      <Layout>
+        <Title>Loading Ticket…</Title>
+        <Spinner />
+      </Layout>
+    )
+
+  const {
+    fields: { Name: name, "Has grocery needs?": grocery, Phone: phone },
+  } = record
+  console.log(name, grocery, phone)
+
+  return (
+    <Layout>
+      <Title>View Ticket</Title>
+      <Record>
+        <Divider />
+        <Field>
+          <Label>Name</Label>
+          <Value>{record.fields["Name"]}</Value>
+        </Field>
+        <Divider />
+        <Field>
+          <Label>Phone</Label>
+          <Value>{record.fields["Phone"]}</Value>
+        </Field>
+        <Divider />
+        <Field>
+          <Label>Has grocery needs?</Label>
+          <Value>{record.fields["Has grocery needs"] ? "Yes" : "No"}</Value>
+        </Field>
+        <Divider />
+        <Field>
+          <Label>Notes</Label>
+          <Value>{record.fields["Notes"]}</Value>
+        </Field>
+        <Divider />
+      </Record>
+
+      <Heading as="h2" fontSize={24}>
+        Complete intake
+      </Heading>
+
+      <Text my={2}>Add an intake note</Text>
+      <Textarea my={2} maxW="40em"></Textarea>
+      <Button
+        my={2}
+        onClick={async () => {
+          alert("would save here...")
+        }}
+      >
+        Submit
+      </Button>
+    </Layout>
+  )
+}
+
+const Record = ({ children }) => (
+  <Flex flexDirection="column" mb="2em">
+    {children}
+  </Flex>
+)
+
+const Field = ({ children }) => (
+  <Flex flexDirection={["column", "row"]} my={"0.5em"}>
+    {children}
+  </Flex>
+)
+
+const Label = ({ children }) => (
+  <Text
+    flex={["0 0 auto", "0 0 8em"]}
+    textAlign={["left", "right"]}
+    fontWeight="bold"
+    margin={["0", "0 1em 0 0"]}
+  >
+    {children}
+  </Text>
+)
+
+const Value = ({ children }) => <Box>{children}</Box>
+
+export default TicketPage

--- a/types.ts
+++ b/types.ts
@@ -1,0 +1,16 @@
+export interface AirtableRecordParams {
+  /** Internal id of the base, of the form `app...` */
+  baseId?: string
+
+  /**
+   * Can be either:
+   * - Internal id of the table, of the form `tbl...`
+   * - Human-readable name of the table, e.g. "Requests"
+   *
+   * The internal id will be more resilient to change, of course.
+   */
+  tableIdOrName: string
+
+  /** Internal id of the record, of the form `rec...` */
+  recordId: string
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4503,6 +4503,11 @@ density-clustering@1.3.0:
   resolved "https://registry.yarnpkg.com/density-clustering/-/density-clustering-1.3.0.tgz#dc9f59c8f0ab97e1624ac64930fd3194817dcac5"
   integrity sha1-3J9ZyPCrl+FiSsZJMP0xlIF9ysU=
 
+dequal@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
+  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
+
 des.js@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
@@ -7495,6 +7500,15 @@ q@^1.5.1:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
+query-string@^6.13.7:
+  version "6.13.7"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.7.tgz#af53802ff6ed56f3345f92d40a056f93681026ee"
+  integrity sha512-CsGs8ZYb39zu0WLkeOhe0NMePqgYdAuCqxOYKDR5LVCytDZYMGx3Bb+xypvQvPHVPijRXB0HZNFllCzHRe4gEA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -8292,6 +8306,11 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz#c80757383c28abf7296744998cbc106ae8b854ce"
   integrity sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -8379,6 +8398,11 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-argv@0.3.1:
   version "0.3.1"
@@ -8566,6 +8590,13 @@ supports-color@^7.1.0:
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
+
+swr@^0.3.8:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-0.3.8.tgz#b3c3c7fa278913d22dbe1f3f28c07df9da9be944"
+  integrity sha512-EHRlaqoBtHsB2wOB+dQJ74DrZvaRGu4BaIQrhkD+/rj8/UGo2iQXN+rCcYnV7/VAreBJBmm9+lDkwZmUqWEkKA==
+  dependencies:
+    dequal "2.0.2"
 
 symbol-observable@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
- Adds a page at `/intake/:recordId` that exposes a limited view of a Requester record and some form fields for updating
- Adds `useAirtableRecord` and `useAirtableRecordUpdate` hooks to simplify usage of SWR with Airtable-backed data
