### PR TITLE
feat: improve driver popup

### DIFF
--- a/components/EvangelMap/Summary.tsx
+++ b/components/EvangelMap/Summary.tsx
@@ -22,6 +22,9 @@ export const Summary: React.FC = () => {
           e.preventDefault()
           isMinimized ? maximize() : minimize()
         }}
+        style={{
+          textDecoration: "underline",
+        }}
       >
         {isMinimized ? "Maximize" : "Minimize"}
       </a>

--- a/components/EvangelMap/index.tsx
+++ b/components/EvangelMap/index.tsx
@@ -73,6 +73,7 @@ export const EvangelMap: React.FC<EvangelMapProps> = ({
           "Language",
           "Phone",
           "Whatsapp Only",
+          "Suggested order",
         ],
       })
       setAllRecipientItems({ data: recipientRecords })

--- a/components/EvangelMap/store/recipients.ts
+++ b/components/EvangelMap/store/recipients.ts
@@ -52,6 +52,9 @@ export interface RecipientFields {
 
   /** Geocoded address, encoded */
   "Geocode cache": string
+
+  /** Suggested order, based on Mapquest route optimizer results */
+  "Suggested order": number
 }
 
 export type RecipientRecord = Airtable.Record<RecipientFields>


### PR DESCRIPTION
- show the actually assigned driver in the popup (fixes edge case where nearby neighbor listed in the popup is unassigned or assigned to a different driver)
- show the drivers' suggested stop orders
- make the maximize/minimize link look clickable

![Screen Shot 2020-11-21 at 3 47 10 PM](https://user-images.githubusercontent.com/140521/99887268-ec455e00-2c10-11eb-9975-0906adb5f373.png)
