### PR TITLE
chore: remove Whatsapp field from query and UI

### DIFF
--- a/components/EvangelMap/DriverList.tsx
+++ b/components/EvangelMap/DriverList.tsx
@@ -288,12 +288,7 @@ const Recipient: React.FC<RecipientProps> = (props) => {
           </a>
         </div>
 
-        <div className="phone">
-          {recipient.fields.Phone?.[0]}{" "}
-          {recipient.fields["Whatsapp Only"]?.[0] && (
-            <span className="whatsapp-warning">⚠️ WhatsApp only</span>
-          )}
-        </div>
+        <div className="phone">{recipient.fields.Phone?.[0]}</div>
 
         {hasNotes && (
           <>
@@ -344,11 +339,6 @@ const Recipient: React.FC<RecipientProps> = (props) => {
 
         .phone {
           padding: 0.125em 0;
-        }
-
-        .whatsapp-warning {
-          opacity: 0.6;
-          padding-left: 0.25em;
         }
 
         ul.notes {

--- a/components/EvangelMap/index.tsx
+++ b/components/EvangelMap/index.tsx
@@ -72,7 +72,6 @@ export const EvangelMap: React.FC<EvangelMapProps> = ({
           "Dietary restrictions",
           "Language",
           "Phone",
-          "Whatsapp Only",
           "Suggested order",
         ],
       })

--- a/components/EvangelMap/store/recipients.ts
+++ b/components/EvangelMap/store/recipients.ts
@@ -44,9 +44,6 @@ export interface RecipientFields {
   /** Phone lookup for the linked Request table record */
   Phone: string[]
 
-  /** WhatsApp lookup for the linked Request table record */
-  "Whatsapp Only": boolean[]
-
   /** Best address */
   "Address (computed)": string
 


### PR DESCRIPTION
This follows from the Airtable cleanup, which removed the "WhatsApp only" field from the Requesters table:

> Was useful but not part of the intake form anymore?

