### PR TITLE
feat: add route optimization UI

### DIFF
--- a/components/EvangelMap/Help.tsx
+++ b/components/EvangelMap/Help.tsx
@@ -26,9 +26,7 @@ export const Help: React.FC = () => {
               <Heading as="h2" fontSize="24px">
                 Airtable Route Planner
               </Heading>
-
               <Text my={3}>Check out the notes below.</Text>
-
               <Text my={3}>
                 If you still have questions drop em in the the{" "}
                 {/* TODO: figure out how to color hyperlinks?! */}
@@ -39,16 +37,13 @@ export const Help: React.FC = () => {
                 </Text>{" "}
                 channel
               </Text>
-
               <Heading as="h3" mt={4} fontSize="18px">
                 What this is
               </Heading>
-
               <Text my={3}>
                 This map app provides a friendlier view into the Airtable tables
                 we use to manage deliveries.
               </Text>
-
               <Text my={3}>
                 All <em>updates</em> to driving assignments are still made in
                 the Airtable interface, but this map interface should make it
@@ -56,15 +51,12 @@ export const Help: React.FC = () => {
                 where they are coming from, which stops are assigned to them,
                 which stops still need to be assigned, and so on.
               </Text>
-
               <Heading as="h3" mt={4} fontSize="18px">
                 How to use this
               </Heading>
-
               <Text my={3}>
                 There are basically two different ways to get this done:
               </Text>
-
               <List
                 as="ol"
                 pl="1em"
@@ -133,8 +125,28 @@ export const Help: React.FC = () => {
 
               <Text my={3}>
                 Once all assignments are done, use the{" "}
-                <LilButton>Mapquest</LilButton> button to copy a driver
-                itinerary into{" "}
+                <LilButton>Mapquest</LilButton> button to see an optimized route
+                according to Mapquest. If the route information and preview map
+                look reasonable, go to Airtable and populate the "Suggested
+                order" column in the Delivery Recipients table to indicate the
+                optimized itinerary.
+              </Text>
+
+              <Text my={3}>
+                If the route looks funky you may need to optimize the route the
+                old-fashioned way:
+              </Text>
+
+              <Text
+                my={3}
+                fontSize={14}
+                pl={3}
+                lineHeight={1.5}
+                borderLeft="solid 1px gray"
+              >
+                Pressing the <LilButton>Mapquest</LilButton> button also copies
+                that driver's itinerary to your clipboard, so you can copy a
+                driver itinerary into{" "}
                 <Text as="span" textDecoration="underline">
                   <Link
                     target="mapquest"
@@ -194,6 +206,7 @@ export const Help: React.FC = () => {
                   to match the name of the upcoming delivery, e.g. `Evangel -
                   2020-07-07`
                 </ListItem>
+
                 <ListItem my={3}>
                   Double check that the Map App in{" "}
                   <strong>

--- a/components/EvangelMap/Map.tsx
+++ b/components/EvangelMap/Map.tsx
@@ -119,7 +119,7 @@ const Map: React.FC = () => {
 
       <style jsx global>
         {`
-          .leaflet-container {
+          .big-map-container > .leaflet-container {
             width: 100%;
             height: calc(100vh - 5rem);
           }

--- a/components/EvangelMap/Map.tsx
+++ b/components/EvangelMap/Map.tsx
@@ -5,7 +5,7 @@ import { GeoJSON, Map as ReactLeafletMap, TileLayer } from "react-leaflet"
 import { CircleMarker } from "leaflet"
 import { Feature, Point } from "geojson"
 import { distance, getCoord } from "@turf/turf"
-import { Box, Divider } from "@chakra-ui/react"
+import { Box, Text } from "@chakra-ui/react"
 
 import { useStoreState, useStoreActions } from "./store"
 import { RecipientFields } from "./store/recipients"
@@ -159,9 +159,8 @@ const PopupContent: React.FC<{
         feature={feature}
         drivers={drivers}
       ></AirtableRecordLink>
-      <Divider my={2} borderColor="#999" />
-      Other stops at or near this address:
-      <Box>
+      <Box borderTop="solid 1px #999" mt={8} pt={8}>
+        <Text as="div">Other stops at or near this address:</Text>
         {neighbors.map((n) => (
           <Box my={1} key={n.id}>
             <AirtableRecordLink

--- a/components/EvangelMap/RouteOptimizer.tsx
+++ b/components/EvangelMap/RouteOptimizer.tsx
@@ -1,0 +1,103 @@
+import { useStoreState, useStoreActions } from "./store"
+import { decodeGeodata } from "airtable-geojson"
+import {
+  Box,
+  Button,
+  ListItem,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  OrderedList,
+  Spinner,
+  Text,
+} from "@chakra-ui/react"
+
+export const RouteOptimizer: React.FC = () => {
+  const { isRouteOptimizerVisible, currentOptimizedRoute } = useStoreState(
+    (state) => state.app
+  )
+  const { hideRouteOptimizer, clearCurrentOptimizedRoute } = useStoreActions(
+    (actions) => actions.app
+  )
+
+  let startAt: string, endAt: string
+
+  if (currentOptimizedRoute) {
+    startAt = currentOptimizedRoute.pickupAddress.split(/,/)[0]
+    endAt = decodeGeodata(
+      currentOptimizedRoute.driver.fields["Geocode cache"]
+    )?.o?.formattedAddress?.replace(/, USA$/, "")
+  }
+
+  const teardown = () => {
+    hideRouteOptimizer()
+    clearCurrentOptimizedRoute()
+  }
+
+  return (
+    <Modal isOpen={isRouteOptimizerVisible} onClose={teardown}>
+      <ModalOverlay />
+      <ModalContent minWidth={"40em"}>
+        <ModalHeader>
+          {currentOptimizedRoute
+            ? `Optimized route for ${currentOptimizedRoute?.driver?.fields?.Name}`
+            : "Loading…"}
+        </ModalHeader>
+        <ModalCloseButton />
+        {currentOptimizedRoute ? (
+          <ModalBody>
+            <Text my={4}>
+              According to Mapquest this is the optimized order for the stops on
+              this driver's list — starting with the pickup location, continuing
+              through all the stops, and ending at the driver's home location:
+            </Text>
+
+            <OrderedList>
+              <Text color="gray.400">Starting at {startAt}</Text>
+
+              {currentOptimizedRoute.orderedRecipients.map((r) => {
+                const recipientAddress = decodeGeodata(
+                  r.fields["Geocode cache"]
+                )?.o?.formattedAddress?.replace(/, USA$/, "")
+
+                return (
+                  <ListItem key={r.id} my={1}>
+                    <Text fontWeight="bold">{r.fields.NameLookup}</Text>
+                    <Text color="gray.600">{recipientAddress}</Text>
+                  </ListItem>
+                )
+              })}
+
+              <Text color="gray.400">Ending at {endAt || "?"}</Text>
+            </OrderedList>
+
+            <Text my={4}>
+              If this looks reasonable, go ahead and enter this order into
+              Airtable. Then reload the route planning page to see the order
+              reflected on the big map, and verify that it makes sense.
+            </Text>
+          </ModalBody>
+        ) : (
+          <ModalBody>
+            <Box textAlign="center">
+              <Text display="inline-block">
+                Loading results from Mapquest…&nbsp;
+              </Text>
+              <Spinner verticalAlign="middle" />
+            </Box>
+          </ModalBody>
+        )}
+        <ModalFooter>
+          {/* <Button variant="ghost" onClick={teardown}> Cancel </Button> */}
+          <Button colorScheme="blue" mr={3} onClick={teardown}>
+            Got it
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/components/EvangelMap/RouteOptimizer.tsx
+++ b/components/EvangelMap/RouteOptimizer.tsx
@@ -73,6 +73,11 @@ export const RouteOptimizer: React.FC = () => {
               })}
 
               <Text color="gray.400">Ending at {endAt || "?"}</Text>
+              <Text mt={2} color="gray.500" fontSize={12}>
+                After pickup, estimated:{" "}
+                {currentOptimizedRoute.stats.distance.toFixed()} mi /{" "}
+                {currentOptimizedRoute.stats.formattedTime}
+              </Text>
             </OrderedList>
 
             <Text my={4}>

--- a/components/EvangelMap/RoutingResult.tsx
+++ b/components/EvangelMap/RoutingResult.tsx
@@ -1,0 +1,200 @@
+import React, { useEffect, useRef } from "react"
+import {
+  Box,
+  Flex,
+  ListItem,
+  ModalBody,
+  OrderedList,
+  Text,
+  UnorderedList,
+} from "@chakra-ui/react"
+import { decodeGeodata } from "airtable-geojson"
+import * as L from "leaflet"
+import { OptimizedRoute } from "../../lib/optimized-route"
+
+interface Props {
+  currentOptimizedRoute: OptimizedRoute
+}
+
+const RoutingResult: React.FC<Props> = ({ currentOptimizedRoute }) => {
+  let startAt: string, endAt: string
+
+  if (currentOptimizedRoute) {
+    startAt = currentOptimizedRoute.pickupAddress.split(/,/)[0]
+    endAt = decodeGeodata(
+      currentOptimizedRoute.driver.fields["Geocode cache"]
+    )?.o?.formattedAddress?.replace(/, USA$/, "")
+  }
+
+  const mapDiv = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (currentOptimizedRoute.orderedRecipients.length > 20)
+      throw new Error("Holy crap, I can't handle this many stops")
+
+    const map = L.map(mapDiv.current).setView([40.7, -73.85], 11)
+
+    L.tileLayer(
+      "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png",
+      {
+        attribution:
+          ' &copy; <a href="https://carto.com/attributions">CARTO</a>',
+      }
+    ).addTo(map)
+
+    const icons = Array.from({ length: 20 }).map((_, i) =>
+      L.divIcon({ className: `my-div-icon my-div-icon-${i}` })
+    )
+
+    const latLngs: L.LatLngExpression[] = currentOptimizedRoute.orderedRecipients.map(
+      (r) => {
+        const {
+          o: { lat, lng },
+        } = decodeGeodata(r.fields["Geocode cache"])
+        return [lat, lng]
+      }
+    )
+
+    const routeSegments = L.polyline(latLngs, { color: "#00000022", weight: 4 })
+    routeSegments.addTo(map)
+
+    const stops = latLngs.map((ll, i) => {
+      return L.marker(ll, { icon: icons[i] })
+    })
+    L.layerGroup(stops).addTo(map)
+
+    const bounds = L.latLngBounds(stops.map((s) => s.getLatLng()))
+    map.fitBounds(bounds)
+  }, [])
+
+  return (
+    <ModalBody>
+      <Text my={4}>
+        According to Mapquest this is the optimized order for the stops on this
+        driver’s list:
+      </Text>
+
+      <Flex w="100%" h={"auto"}>
+        <Box flex="1">
+          <OrderedList>
+            <Text color="gray.400">Starting at {startAt}</Text>
+
+            {currentOptimizedRoute.orderedRecipients.map((r) => {
+              const recipientAddress = decodeGeodata(
+                r.fields["Geocode cache"]
+              )?.o?.formattedAddress?.replace(/, USA$/, "")
+
+              return (
+                <ListItem key={r.id} my={1}>
+                  <Text fontWeight="bold">{r.fields.NameLookup}</Text>
+                  <Text color="gray.600">{recipientAddress}</Text>
+                </ListItem>
+              )
+            })}
+
+            <Text color="gray.400">Ending at {endAt || "?"}</Text>
+            <Text mt={2} color="gray.500" fontSize={12}>
+              After pickup, estimated distance/time:{" "}
+              {currentOptimizedRoute.stats.distance.toFixed()} mi /{" "}
+              {currentOptimizedRoute.stats.formattedTime}
+            </Text>
+          </OrderedList>
+        </Box>
+        <Box ref={mapDiv} flex="1" minHeight="30em"></Box>
+      </Flex>
+
+      <Text mt={4} color="gray.600">
+        <strong>Notes</strong>
+      </Text>
+
+      <UnorderedList color="gray.600">
+        <ListItem>
+          Some adjacent stops might be sitting on top of one another on the map
+          above. You can zoom in to try to get a closer look.
+        </ListItem>
+        <ListItem>
+          The line shown on the map is just to make the order clearer; it does
+          not indicate the turn-by-turn travel directions.
+        </ListItem>
+      </UnorderedList>
+
+      <Text my={4}>
+        If this route looks reasonable, go ahead and enter this order into
+        Airtable. Then reload the route planning app to see the order reflected
+        on the big map, and verify that it makes sense.
+      </Text>
+
+      <style jsx global>{`
+        .my-div-icon {
+          color: black;
+          font-weight: bold;
+          font-size: 1.25rem;
+          white-space: nowrap;
+          text-shadow: 0 0 3px white, 0 0 2px white, 0 0 1px white;
+        }
+        .my-div-icon-0::before {
+          content: "1";
+        }
+        .my-div-icon-1::before {
+          content: "2";
+        }
+        .my-div-icon-2::before {
+          content: "3";
+        }
+        .my-div-icon-3::before {
+          content: "4";
+        }
+        .my-div-icon-4::before {
+          content: "5";
+        }
+        .my-div-icon-5::before {
+          content: "6";
+        }
+        .my-div-icon-6::before {
+          content: "7";
+        }
+        .my-div-icon-7::before {
+          content: "8";
+        }
+        .my-div-icon-8::before {
+          content: "9";
+        }
+        .my-div-icon-9::before {
+          content: "10";
+        }
+        .my-div-icon-10::before {
+          content: "11";
+        }
+        .my-div-icon-11::before {
+          content: "12";
+        }
+        .my-div-icon-12::before {
+          content: "13";
+        }
+        .my-div-icon-13::before {
+          content: "14";
+        }
+        .my-div-icon-14::before {
+          content: "15";
+        }
+        .my-div-icon-15::before {
+          content: "16";
+        }
+        .my-div-icon-16::before {
+          content: "17";
+        }
+        .my-div-icon-17::before {
+          content: "18";
+        }
+        .my-div-icon-18::before {
+          content: "19";
+        }
+        .my-div-icon-19::before {
+          content: "20";
+        }
+      `}</style>
+    </ModalBody>
+  )
+}
+
+export default RoutingResult

--- a/components/EvangelMap/index.tsx
+++ b/components/EvangelMap/index.tsx
@@ -8,6 +8,7 @@ import { InfoSidebar } from "./InfoSidebar"
 import { API } from "../../lib/api"
 import { DriverFields } from "./store/drivers"
 import { RecipientFields } from "./store/recipients"
+import { RouteOptimizer } from "./RouteOptimizer"
 
 const MapWithNoSSR = dynamic(() => import("./Map"), { ssr: false })
 
@@ -83,6 +84,7 @@ export const EvangelMap: React.FC<EvangelMapProps> = ({
 
   return (
     <>
+      <RouteOptimizer />
       <Flex direction="row">
         <Box flex="3">
           <MapWithNoSSR />

--- a/components/EvangelMap/index.tsx
+++ b/components/EvangelMap/index.tsx
@@ -86,7 +86,7 @@ export const EvangelMap: React.FC<EvangelMapProps> = ({
     <>
       <RouteOptimizer />
       <Flex direction="row">
-        <Box flex="3">
+        <Box flex="3" className="big-map-container">
           <MapWithNoSSR />
         </Box>
         <Box flex="1" height="calc(100vh - 5rem)" minW="25em" overflow="scroll">

--- a/components/EvangelMap/store/app.ts
+++ b/components/EvangelMap/store/app.ts
@@ -1,4 +1,5 @@
 import { action, Action } from "easy-peasy"
+import { OptimizedRoute } from "../../../lib/optimized-route"
 import { readFromLocalStorage } from "../../../lib/localStorage"
 
 const defaultPickupLocationIndex = (readFromLocalStorage(
@@ -14,6 +15,10 @@ export interface AppModel {
 
   currentPickupLocationIndex: number
 
+  currentOptimizedRoute: OptimizedRoute
+
+  isRouteOptimizerVisible: boolean
+
   // ACTIONS
 
   showHelp: Action<AppModel>
@@ -26,6 +31,14 @@ export interface AppModel {
 
   setPickupLocationIndex: Action<AppModel, { pickupLocationIndex: number }>
 
+  setCurrentOptimizedRoute: Action<AppModel, { optimizedRoute: OptimizedRoute }>
+
+  clearCurrentOptimizedRoute: Action<AppModel>
+
+  showRouteOptimizer: Action<AppModel>
+
+  hideRouteOptimizer: Action<AppModel>
+
   // LISTENERS
 }
 
@@ -37,6 +50,10 @@ export const appModel: AppModel = {
   isDriverListMinimized: false,
 
   currentPickupLocationIndex: defaultPickupLocationIndex,
+
+  currentOptimizedRoute: null,
+
+  isRouteOptimizerVisible: false,
 
   // ACTIONS
 
@@ -58,6 +75,22 @@ export const appModel: AppModel = {
 
   setPickupLocationIndex: action((state, payload) => {
     state.currentPickupLocationIndex = payload.pickupLocationIndex
+  }),
+
+  setCurrentOptimizedRoute: action((state, payload) => {
+    state.currentOptimizedRoute = payload.optimizedRoute
+  }),
+
+  clearCurrentOptimizedRoute: action((state) => {
+    state.currentOptimizedRoute = null
+  }),
+
+  hideRouteOptimizer: action((state) => {
+    state.isRouteOptimizerVisible = false
+  }),
+
+  showRouteOptimizer: action((state) => {
+    state.isRouteOptimizerVisible = true
   }),
 
   // LISTENERS

--- a/lib/optimized-route.ts
+++ b/lib/optimized-route.ts
@@ -11,7 +11,7 @@ export class OptimizedRoute {
   public pickupAddress: string
   private recipients: RecipientRecord[]
   public driver: DriverRecord
-  private response: MapquetApiResponse
+  private response: MapquestApiResponse
 
   /**
    * Factory method that encapsulates the creation of a Mapquest optimized
@@ -33,6 +33,14 @@ export class OptimizedRoute {
       .slice(1, -1) // i.e. the middle bit, without initial pickup and driver's final home stop
       .map((i) => i - 1) // decremented to the correct range
     return recipientSequence.map((idx) => this.recipients[idx])
+  }
+
+  public get stats(): Pick<Route, "distance" | "formattedTime"> {
+    const {
+      route: { distance, formattedTime },
+    } = this.response
+
+    return { distance, formattedTime }
   }
 
   /** Private constructor method, used only by the `create` factory method */
@@ -79,7 +87,7 @@ export class OptimizedRoute {
       }
 
       const response: Response = await fetch(url, options)
-      const json: MapquetApiResponse = await response.json()
+      const json: MapquestApiResponse = await response.json()
       this.response = json
     } catch (error) {
       console.error({ error })
@@ -88,15 +96,16 @@ export class OptimizedRoute {
   }
 }
 
-interface MapquetApiResponse {
-  route: {
-    distance: number
-    formattedTime: string
-    fuelUsed: number
-    locations: Location[]
-    locationSequence: number[]
-    routeError: unknown
-  }
+interface Route {
+  distance: number
+  formattedTime: string
+  fuelUsed: number
+  locations: Location[]
+  locationSequence: number[]
+  routeError: unknown
+}
+interface MapquestApiResponse {
+  route: Route
 }
 
 interface Location {

--- a/lib/optimized-route.ts
+++ b/lib/optimized-route.ts
@@ -1,0 +1,159 @@
+import { RecipientRecord } from "../components/EvangelMap/store/recipients"
+import { decodeGeodata } from "airtable-geojson"
+import { DriverRecord } from "../components/EvangelMap/store/drivers"
+
+/**
+ * Represents an optimized routing request
+ *
+ * https://developer.mapquest.com/documentation/directions-api/optimized-route/post/
+ */
+export class OptimizedRoute {
+  public pickupAddress: string
+  private recipients: RecipientRecord[]
+  public driver: DriverRecord
+  private response: MapquetApiResponse
+
+  /**
+   * Factory method that encapsulates the creation of a Mapquest optimized
+   * route request, and returns an instance that is ready to use.
+   */
+  static create = async (
+    pickupAddress: string,
+    recipients: RecipientRecord[],
+    driver: DriverRecord
+  ): Promise<OptimizedRoute> => {
+    const route = new OptimizedRoute(pickupAddress, recipients, driver)
+    await route.fetch()
+    return route
+  }
+
+  /** Returns the input recipient records, in optimized order */
+  public get orderedRecipients(): RecipientRecord[] {
+    const recipientSequence = this.locationSequence
+      .slice(1, -1) // i.e. the middle bit, without initial pickup and driver's final home stop
+      .map((i) => i - 1) // decremented to the correct range
+    return recipientSequence.map((idx) => this.recipients[idx])
+  }
+
+  /** Private constructor method, used only by the `create` factory method */
+  private constructor(
+    pickupAddress: string,
+    recipients: RecipientRecord[],
+    driver: DriverRecord
+  ) {
+    this.pickupAddress = pickupAddress
+    this.recipients = recipients
+    this.driver = driver
+  }
+
+  /** Returns an array corresponding to the optimized order of the input recipients */
+  private get locationSequence(): number[] {
+    return this.response.route.locationSequence
+  }
+
+  /** Returns the normalized addresses, using the cached Google geocoder result */
+  private get allAddresses(): string[] {
+    const recipientAddresses = this.recipients.map(
+      (r) => decodeGeodata(r.fields["Geocode cache"]).o.formattedAddress
+    )
+    const driverAddress = decodeGeodata(this.driver.fields["Geocode cache"]).o
+      .formattedAddress
+    return [this.pickupAddress, ...recipientAddresses, driverAddress]
+  }
+
+  /** Performs the MapQuest API request and stores the result */
+  private fetch = async (): Promise<void> => {
+    try {
+      console.log("Sending", this.allAddresses)
+      const url = `http://www.mapquestapi.com/directions/v2/optimizedroute?key=${process.env.NEXT_PUBLIC_MAPQUEST_API_KEY}`
+      const options = {
+        method: "POST",
+        mode: "cors" as RequestMode, // no-cors, *cors, same-origin
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({
+          locations: this.allAddresses,
+        }),
+      }
+
+      const response: Response = await fetch(url, options)
+      const json: MapquetApiResponse = await response.json()
+      this.response = json
+    } catch (error) {
+      console.error({ error })
+      throw error
+    }
+  }
+}
+
+interface MapquetApiResponse {
+  route: {
+    distance: number
+    formattedTime: string
+    fuelUsed: number
+    locations: Location[]
+    locationSequence: number[]
+    routeError: unknown
+  }
+}
+
+interface Location {
+  /** e.g. "US" */
+  adminArea1: string
+
+  /** e.g. "Country" */
+  adminArea1Type: string
+
+  /** e.g. "NY" */
+  adminArea3: string
+
+  /** e.g. "State" */
+  adminArea3Type: string
+
+  /** e.g. "Queens" */
+  adminArea4: string
+
+  /** e.g. "County" */
+  adminArea4Type: string
+
+  /** e.g. "Queens" */
+  adminArea5: string
+
+  /** e.g. "City" */
+  adminArea5Type: string
+
+  displayLatLng: {
+    lng: number
+    lat: number
+  }
+
+  dragPoint: boolean
+
+  /** e.g. "ADDRESS" */
+  geocodeQuality: string
+
+  /** e.g. "L1AAA" */
+  geocodeQualityCode: string
+
+  latLng: {
+    lng: number
+    lat: number
+  }
+
+  /** e.g. "567850" */
+  linkId: number
+
+  /** e.g. "11101" */
+  postalCode: string
+
+  /** e.g. "L" */
+  sideOfStreet: string
+
+  /** e.g. "1337 42nd St" */
+  street: string
+
+  /** e.g. "s" */
+  type: string
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/chroma-js": "^2.1.0",
     "@types/clipboard": "^2.0.1",
     "@types/geojson": "^7946.0.7",
+    "@types/leaflet": "^1.5.23",
     "@types/lodash": "^4.14.162",
     "@types/next-auth": "^3.1.11",
     "@types/node": "^14.11.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3115,7 +3115,7 @@
   resolved "https://registry.yarnpkg.com/@types/clipboard/-/clipboard-2.0.1.tgz#75a74086c293d75b12bc93ff13bc7797fef05a40"
   integrity sha512-gJJX9Jjdt3bIAePQRRjYWG20dIhAgEqonguyHxXuqALxsoDsDLimihqrSg8fXgVTJ4KZCzkfglKtwsh/8dLfbA==
 
-"@types/geojson@^7946.0.7":
+"@types/geojson@*", "@types/geojson@^7946.0.7":
   version "7946.0.7"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.7.tgz#c8fa532b60a0042219cdf173ca21a975ef0666ad"
   integrity sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==
@@ -3124,6 +3124,13 @@
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
+
+"@types/leaflet@^1.5.23":
+  version "1.5.23"
+  resolved "https://registry.yarnpkg.com/@types/leaflet/-/leaflet-1.5.23.tgz#159823a8c86a50383f0c9d9b9dac2af01fa7603b"
+  integrity sha512-S/xpuwjZuwYMP+4ZzQ10PX0Jy+0XmwPeojtjqhbca9UXaINdoru91Qm/DUUXyh4qYm3CP6Vher06l/UcA9tUKQ==
+  dependencies:
+    "@types/geojson" "*"
 
 "@types/lodash.mergewith@4.6.6":
   version "4.6.6"


### PR DESCRIPTION
Improves on the current super-basic copy-paste setup by:

- sending the current itinerary to the Mapquest API
- displaying the results in a modal:
  - a list of the suggested ordering as well as
  - an inset map for previewing the ordering
- prompting user to manually enter the suggested order over in Airtable

Also:

- fix a minor style regression on the big map re: clustered stops
- add @types/leaflet since we use that directly (instead of react-leaflet) in the modal UI