### PR TITLE
feat: allow intake form to update requester status

### DIFF
--- a/pages/intake/[id].tsx
+++ b/pages/intake/[id].tsx
@@ -166,6 +166,7 @@ const IntakePage: React.FC = () => {
               my={3}
               maxW="40em"
               placeholder="Add more intake notes"
+              display="block"
             ></Textarea>
           </Value>
         </Field>

--- a/pages/intake/[id].tsx
+++ b/pages/intake/[id].tsx
@@ -94,8 +94,8 @@ const IntakePage: React.FC = () => {
           <Value>
             {record.fields[
               "Which of these ways are best to get in touch with you?"
-            ].map((t) => (
-              <div>{t}</div>
+            ]?.map((t) => (
+              <div key={t}>{t}</div>
             ))}
           </Value>
         </Field>

--- a/pages/intake/[id].tsx
+++ b/pages/intake/[id].tsx
@@ -134,7 +134,7 @@ const IntakePage: React.FC = () => {
           <Value>
             <Checkbox
               ref={groceryNeedsRef}
-              defaultIsChecked={record.fields["Has grocery needs"]}
+              defaultChecked={record.fields["Has grocery needs"]}
             />
           </Value>
         </Field>
@@ -144,7 +144,7 @@ const IntakePage: React.FC = () => {
           <Value>
             <Checkbox
               ref={immediateFoodNeedsRef}
-              defaultIsChecked={record.fields["Needs immediate food delivery"]}
+              defaultChecked={record.fields["Needs immediate food delivery"]}
             />
           </Value>
         </Field>
@@ -153,7 +153,7 @@ const IntakePage: React.FC = () => {
           <Label>9MR Waitlist</Label>
           <Checkbox
             ref={waitlist9mrRef}
-            defaultIsChecked={record.fields["9MR wait list"]}
+            defaultChecked={record.fields["9MR wait list"]}
           />
         </Field>
 

--- a/schemas/requester.ts
+++ b/schemas/requester.ts
@@ -33,7 +33,7 @@ export interface RequesterFields {
   "Point person": string[]
 
   /** Status (fld4AUQU48pbrjafM) -- singleSelect */
-  Status: unknown
+  Status: string
 
   /** How soon do you need support? (fldFxRRTP6FbdBhpE) -- singleSelect */
   "How soon do you need support?": unknown
@@ -190,4 +190,21 @@ export interface RequesterFields {
 
   /** Intake form (fld9DTKuWX7NQEYm8) -- button */
   "Intake form": unknown
+}
+
+export enum RequesterStatus {
+  New = "New - Needs intake",
+  Intake = "Intake in progress",
+  ResolvedAble = "Resolved - Able to Fill Need",
+  ResolvedDuplicate = "Resolved - Duplicate",
+
+  // Waiting for a response from them
+  // Needs volunteer
+  // In Progress - We Take Responsibility For This (DO NOT USE THIS
+  // Scheduled with volunteer
+  // Unable to contact
+  // We Can’t Take Responsibility for This
+  // EMERGENCY- Has Urgent Needs to be
+  // Resolved - Follow up next week
+  // Resolved - Cancelled
 }


### PR DESCRIPTION
Adds a new Status section to the form so that Airtable access is not required for moving a record to the appropriate status.

- Prior to this change the app would automatically transition a record from from New → In Progress, but would not allow any further status changes via the form

- Now it allows transitions from In Progress to a couple of Resolved states as well

![Screen Shot 2021-04-23 at 6 16 15 PM](https://user-images.githubusercontent.com/140521/115935014-46687a80-a460-11eb-9c16-5776935c9830.png)
