### PR TITLE
feat: add check for cash grant history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+pages/scratch.tsx

--- a/lib/hooks/airtable-records.ts
+++ b/lib/hooks/airtable-records.ts
@@ -1,0 +1,98 @@
+import useSWR, { responseInterface } from "swr"
+import { stringifyUrl } from "query-string"
+
+import { AirtableRecordListParams } from "../../types"
+
+interface Response<TFields> {
+  /** The retrieved records */
+  records: Airtable.Records<TFields>
+
+  /** A formatted error object, in case the records could not be retrieved */
+  error: AirtableRecordException
+
+  /** True if the request is still in progress */
+  isLoading: boolean
+
+  /** True if the request has errored */
+  isError: boolean
+
+  /**
+   * TODO: deprecation
+   * Mutate function, bound to SWR cache key
+   */
+  mutate: responseInterface<
+    Airtable.Record<TFields>,
+    AirtableRecordException
+  >["mutate"]
+}
+
+/**
+ * An SWR data fetching hook that will return a list of Airtable records in their entirety.
+ *
+ * Do not use if you wish to avoid sending some fields over the wire.
+ */
+export const useAirtableRecords = <TFields>({
+  baseId,
+  tableIdOrName,
+  maxRecords,
+  fields,
+  filterByFormula,
+  sort,
+  view,
+}: AirtableRecordListParams): Response<TFields> => {
+  const url = stringifyUrl(
+    {
+      url: `/api/airtable-records`,
+      query: {
+        baseId,
+        tableIdOrName,
+        maxRecords,
+        fields,
+        filterByFormula,
+        view,
+        sort: JSON.stringify(sort),
+      },
+    },
+    {
+      skipNull: true,
+    }
+  )
+
+  const { data, error, mutate } = useSWR(url, fetcher)
+
+  return {
+    records: data,
+    error,
+    isLoading: !error && !data,
+    isError: !!error,
+    mutate,
+  }
+}
+
+const fetcher = async (url: string) => {
+  const res = await fetch(url)
+  if (!res.ok) {
+    const error = new AirtableRecordException(
+      "An error occurred while getting the records."
+    )
+    error.details = await res.json()
+    throw error
+  }
+  // await sleep({ ms: 2000 });
+  return res.json()
+}
+
+class AirtableRecordException {
+  readonly name: string
+  message: string
+  details: unknown
+
+  constructor(message: string) {
+    this.name = "AirtableRecordException"
+    this.message = message
+  }
+}
+
+// for simulating latency
+// const sleep = ({ ms }) =>
+//   new Promise<void>((resolve) => setTimeout(() => resolve(), ms))

--- a/lib/hooks/index.ts
+++ b/lib/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from "./airtable-record"
+export * from "./airtable-records"
 export * from "./airtable-record-update"

--- a/pages/api/airtable-records.ts
+++ b/pages/api/airtable-records.ts
@@ -1,0 +1,55 @@
+import { NextApiRequest, NextApiResponse } from "next"
+import { getSession } from "next-auth/client"
+import { omitBy, isUndefined } from "lodash"
+
+import { airtable } from "../../lib/airtable"
+import { AirtableRecordListParams } from "../../types"
+
+const records = async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> => {
+  const session = await getSession({ req })
+  if (session) {
+    const {
+      baseId,
+      tableIdOrName,
+      maxRecords,
+      fields,
+      filterByFormula,
+      view,
+      sort,
+    } = (req.query as unknown) as AirtableRecordListParams
+
+    const criteria = omitBy(
+      {
+        maxRecords: parseInt((maxRecords as unknown) as string),
+        fields,
+        filterByFormula,
+        view,
+        sort: JSON.parse((sort as string) || "[]"),
+      },
+      isUndefined
+    )
+
+    try {
+      const base: Airtable.Base = airtable.base(
+        baseId || process.env.AIRTABLE_BASE_ID
+      )
+      const records = await base(tableIdOrName as string)
+        .select(criteria)
+        .all()
+      res.statusCode = 200
+      res.json(records)
+    } catch (error) {
+      res.statusCode = error.statusCode || 500
+      res.json(error)
+    }
+    res.end()
+  } else {
+    res.status(401)
+  }
+  res.end()
+}
+
+export default records

--- a/schemas/requester.ts
+++ b/schemas/requester.ts
@@ -190,6 +190,9 @@ export interface RequesterFields {
 
   /** Intake form (fld9DTKuWX7NQEYm8) -- button */
   "Intake form": unknown
+
+  /** Has received cash grant */
+  "Has received cash grant": boolean
 }
 
 export enum RequesterStatus {

--- a/types.ts
+++ b/types.ts
@@ -1,4 +1,4 @@
-export interface AirtableRecordParams {
+export interface AirtableTableParams {
   /** Internal id of the base, of the form `app...` */
   baseId?: string
 
@@ -10,7 +10,72 @@ export interface AirtableRecordParams {
    * The internal id will be more resilient to change, of course.
    */
   tableIdOrName: string
+}
 
+export interface AirtableRecordParams extends AirtableTableParams {
   /** Internal id of the record, of the form `rec...` */
   recordId: string
+}
+
+export interface AirtableRecordListParams extends AirtableTableParams {
+  /**
+   * Only data for fields whose names are in this list will be included in the result.
+   *
+   * If you don't need every field, you can use this parameter to reduce the amount of data transferred.
+   *
+   * For example, to only return data from Name and URL, pass in:
+   *
+   * `fields: ["Name", "URL"]`
+   */
+  fields?: string[]
+
+  /**
+   * A formula used to filter records. The formula will be evaluated for each record, and if the result is not 0, false, "", NaN, [], or #Error! the record will be included in the response.
+   *
+   * If combined with the view parameter, only records in that view which satisfy the formula will be returned.
+   *
+   * For example, to only include records where Name isn't empty, pass in NOT({Name} = '') as a parameter like this:
+   *
+   * `filterByFormula: "NOT({Name} = '')"`
+   */
+  filterByFormula?: string
+
+  /**
+   * The name or ID of a view in the table. If set, only the records in that view will be returned.
+   *
+   * The records will be sorted according to the order of the view unless the sort parameter is included,
+   * which overrides that order.
+   *
+   * Fields hidden in this view will be returned in the results.
+   * To only return a subset of fields, use the fields parameter.
+   */
+  view?: string
+
+  /**
+   * A list of sort objects that specifies how the records will be ordered.
+   *
+   * Each sort object must have a field key specifying the name of the field to sort on,
+   * and an optional direction key that is either "asc" or "desc".
+   * The default direction is "asc".
+   *
+   * The sort parameter overrides the sorting of the view specified in the view parameter.
+   * If neither the sort nor the view parameter is included, the order of records is arbitrary.
+   *
+   * For example, to sort records by Name in descending order, send these two query parameters:
+   *
+   * sort%5B0%5D%5Bfield%5D=Name
+   * sort%5B0%5D%5Bdirection%5D=desc
+   *
+   * (That is: sort[0][field]=Name&sort[0][direction]=desc )
+   *
+   * For example, to sort records by Name in descending order, pass in:
+   *
+   * [{field: "Name", direction: "desc"}]
+   */
+  sort?: Record<string, unknown>[] | string
+
+  /**
+   * The maximum total number of records that will be returned in your requests.
+   */
+  maxRecords?: number
 }


### PR DESCRIPTION
Adds a check to make it known at intake time whether we have a record of this requested receiving a cash grant previously…

Example when yes:

![yes](https://user-images.githubusercontent.com/140521/119429678-47016480-bcdd-11eb-8b81-a6b6dc6c58f4.png)

Example when no:

![no](https://user-images.githubusercontent.com/140521/119429681-47016480-bcdd-11eb-855f-cc27981b01de.png)
