### PR TITLE
feat: add a new sign-in page

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,19 +1,22 @@
 import { Box } from "@chakra-ui/react"
 import { Navigation } from "../components/Navigation"
+import { BlurredPIIProvider } from "../lib/blurred-pii"
 
 export const Layout: React.FC = ({ children }) => {
   /* TODO: restore maxW={1200} for default layout */
   return (
-    <Box minH="100vh" margin="auto" py="1rem" px="1rem">
-      <header>
-        <nav>
-          <Navigation />
-        </nav>
-      </header>
+    <BlurredPIIProvider shouldBlur={false}>
+      <Box minH="100vh" margin="auto" py="1rem" px="1rem">
+        <header>
+          <nav>
+            <Navigation />
+          </nav>
+        </header>
 
-      <main>{children}</main>
+        <main>{children}</main>
 
-      <footer></footer>
-    </Box>
+        <footer></footer>
+      </Box>
+    </BlurredPIIProvider>
   )
 }

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -12,6 +12,8 @@ import {
 } from "@chakra-ui/react"
 import { signOut, useSession } from "next-auth/client"
 
+import { PII } from "../lib/blurred-pii"
+
 export const Navigation: React.FC = () => {
   const [session] = useSession()
 
@@ -32,7 +34,7 @@ export const Navigation: React.FC = () => {
         <Flex>
           <Menu>
             <MenuButton as={Button} variant="outline">
-              {session.user.name}
+              <PII>{session.user.name}</PII>
             </MenuButton>
             <MenuList>
               <MenuItem

--- a/lib/hooks/airtable-record-create.ts
+++ b/lib/hooks/airtable-record-create.ts
@@ -1,0 +1,67 @@
+import { stringifyUrl } from "query-string"
+
+import { AirtableTableParams } from "../../types"
+
+interface NewRecord<TFields> {
+  fields: TFields
+}
+
+interface Response<TFields> {
+  /** A function to perform the create and promise the created records */
+  createRecords: (
+    records: NewRecord<TFields>[]
+  ) => Promise<Airtable.Records<TFields>>
+}
+
+/**
+ * A hook that provides a function to create one or more Airtable records.
+ *
+ * Returns a promise for the created records, which can be used with an SWR mutation.
+ */
+export const useAirtableRecordCreate = <TFields>({
+  baseId,
+  tableIdOrName,
+}: AirtableTableParams): Response<TFields> => {
+  const url = stringifyUrl(
+    {
+      url: "/api/create-airtable-records",
+      query: { baseId, tableIdOrName },
+    },
+    {
+      skipNull: true,
+    }
+  )
+
+  return {
+    createRecords: creater<TFields>(url),
+  }
+}
+
+const creater = <TFields>(url: string) => async (
+  records: NewRecord<TFields>[]
+): Promise<Airtable.Records<TFields>> => {
+  const res = await fetch(url, {
+    method: "POST",
+    body: JSON.stringify(records),
+  })
+
+  if (!res.ok) {
+    const error = new AirtableRecordCreateException(
+      "An error occurred while creating the records."
+    )
+    error.details = await res.json()
+    throw error
+  }
+  return res.json()
+}
+
+class AirtableRecordCreateException {
+  readonly name: string
+  message: string
+  details: unknown
+
+  constructor(message: string) {
+    this.name = "AirtableRecordCreateException"
+    this.message = message
+  }
+}

--- a/lib/hooks/index.ts
+++ b/lib/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from "./airtable-record"
 export * from "./airtable-records"
 export * from "./airtable-record-update"
+export * from "./airtable-record-create"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "airtable-geojson": "^2.0.0",
     "chroma-js": "^2.1.0",
     "clipboard": "^2.0.6",
+    "date-fns": "^2.22.1",
     "easy-peasy": "^3.3",
     "framer-motion": ">=3.0.0",
     "leaflet": "^1.6",

--- a/pages/api/create-airtable-records.ts
+++ b/pages/api/create-airtable-records.ts
@@ -1,0 +1,37 @@
+import { NextApiRequest, NextApiResponse } from "next"
+import { getSession } from "next-auth/client"
+
+import { airtable } from "../../lib/airtable"
+import { AirtableRecordParams } from "../../types"
+
+const records = async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> => {
+  const session = await getSession({ req })
+  if (session) {
+    const {
+      baseId,
+      tableIdOrName,
+    } = (req.query as unknown) as AirtableRecordParams
+
+    try {
+      const base: Airtable.Base = airtable.base(
+        baseId || process.env.AIRTABLE_BASE_ID
+      )
+
+      const response = await base(tableIdOrName).create(JSON.parse(req.body))
+
+      res.statusCode = 200
+      res.json(response)
+    } catch (error) {
+      res.statusCode = error.statusCode || 500
+      res.json(error)
+    }
+  } else {
+    res.status(401)
+  }
+  res.end()
+}
+
+export default records

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -24,14 +24,10 @@ const Home: React.FC = () => {
       </Text>
 
       <Flex flexDir={["column", "column", "row"]} wrap="wrap">
-        <CardLink
-          title="Sign-in"
-          href={process.env.NEXT_PUBLIC_WEEKLY_SIGN_IN_FORM_URL}
-          external
-        >
+        <CardLink title="Sign-in" href="/sign-in">
           <Text>
             Fill out this form when attending, e.g. the weekly all-hands
-            meetings. <PinCode />
+            meetings.
           </Text>
         </CardLink>
 
@@ -83,7 +79,7 @@ const Home: React.FC = () => {
         >
           <Text>
             Fill out this form to request access to one of our systems or
-            accounts (e.g. Airtable, social media accounts, financial trackers).{" "}
+            accounts (e.g. Airtable, social media accounts, financial trackers).
             <PinCode />
           </Text>
         </CardLink>

--- a/pages/sign-in.tsx
+++ b/pages/sign-in.tsx
@@ -10,11 +10,17 @@ import {
   Spinner,
 } from "@chakra-ui/react"
 
+import { parseISO, format } from "date-fns"
+
 import { Title } from "../components/Title"
 import { Layout } from "../components/Layout"
 import { useAirtableRecords, useAirtableRecordCreate } from "../lib/hooks"
 import { useSession } from "next-auth/client"
 import { MeetingFields } from "../schemas/meeting"
+
+const prettyDate = (date: Date) => {
+  return format(date, "eee, PPP")
+}
 
 const SignInPage: React.FC = () => {
   const [session, loading] = useSession()
@@ -28,7 +34,7 @@ const SignInPage: React.FC = () => {
 
   return (
     <Layout>
-      <Title>Sign-In for {new Date().toLocaleDateString()}</Title>
+      <Title>Sign-In for {prettyDate(new Date())}</Title>
 
       <SignInForm
         name={session.user.name}
@@ -126,19 +132,27 @@ const SignInForm: React.FC<SignInFormProps> = (props) => {
         </Text>
 
         <RadioGroup onChange={setMeetingId} value={meetingId}>
-          {meetings.map((meeting) => (
-            <Box my={2} key={meeting.id}>
-              <Radio size="lg" value={meeting.id} bg="gray.100" display="block">
-                <Text as="span" fontSize="1.25em" fontWeight="bold">
-                  {meeting.fields.Group}
-                </Text>
-                <Text as="span" fontSize="1.25em" ml="0.5em">
-                  {/* TODO: sup with this date?? (treated as UTC?) */}
-                  {new Date(meeting.fields.Date).toLocaleDateString()}
-                </Text>
-              </Radio>
-            </Box>
-          ))}
+          {meetings.map((meeting) => {
+            const formattedDate = prettyDate(parseISO(meeting.fields.Date))
+
+            return (
+              <Box my={2} key={meeting.id}>
+                <Radio
+                  size="lg"
+                  value={meeting.id}
+                  bg="gray.100"
+                  display="block"
+                >
+                  <Text as="span" fontSize="1.25em" fontWeight="bold">
+                    {meeting.fields.Group}
+                  </Text>
+                  <Text as="span" fontSize="1.25em" ml="0.5em">
+                    {formattedDate}
+                  </Text>
+                </Radio>
+              </Box>
+            )
+          })}
         </RadioGroup>
 
         <Button

--- a/pages/sign-in.tsx
+++ b/pages/sign-in.tsx
@@ -1,0 +1,174 @@
+import { useState } from "react"
+import {
+  Text,
+  Box,
+  Radio,
+  RadioGroup,
+  Button,
+  useToast,
+  Link,
+  Spinner,
+} from "@chakra-ui/react"
+
+import { Title } from "../components/Title"
+import { Layout } from "../components/Layout"
+import { useAirtableRecords, useAirtableRecordCreate } from "../lib/hooks"
+import { useSession } from "next-auth/client"
+import { MeetingFields } from "../schemas/meeting"
+
+const SignInPage: React.FC = () => {
+  const [session, loading] = useSession()
+  const { records, isLoading, isError } = useAirtableRecords<MeetingFields>({
+    tableIdOrName: "Meetings",
+    view: "Current",
+  })
+
+  if (isLoading || loading) return <div>...</div>
+  if (isError) return <div>oh shit</div>
+
+  return (
+    <Layout>
+      <Title>Sign-In for {new Date().toLocaleDateString()}</Title>
+
+      <SignInForm
+        name={session.user.name}
+        email={session.user.email}
+        meetings={records}
+      />
+    </Layout>
+  )
+}
+
+interface SignInFormProps {
+  name: string
+  email: string
+  meetings: Airtable.Records<MeetingFields>
+}
+
+const SignInForm: React.FC<SignInFormProps> = (props) => {
+  const { name, email, meetings } = props
+
+  const isOnlyOneMeeting = meetings.length === 1
+  const initialSelection = isOnlyOneMeeting ? meetings[0].id : null
+
+  const [meetingId, setMeetingId] = useState<string | number>(initialSelection)
+
+  const { createRecords } = useAirtableRecordCreate<{
+    Meeting: string[]
+    Attendee: string
+  }>({ tableIdOrName: "Attendances" })
+
+  const [isUpdating, setIsUpdating] = useState<boolean>(false)
+  const toast = useToast()
+
+  const displaySuccessToast = () => {
+    toast({
+      status: "success",
+      position: "top",
+      duration: 3000,
+      title: "Thanks!",
+      description: (
+        <div>
+          You're signed in. You may close this window now or go to the{" "}
+          <Link href="/" textDecoration="underline">
+            homepage
+          </Link>
+          .
+        </div>
+      ),
+      onCloseComplete: () => {
+        window.location.assign("/")
+      },
+    })
+  }
+
+  const displayErrorToast = (e: Error) => {
+    toast({
+      status: "error",
+      position: "top",
+      duration: null,
+      title: "Uh-oh",
+      description: (
+        <div>
+          Seems like that didn't work.
+          {e.message && <p>{e.message}</p>}
+          You can{" "}
+          <Link
+            textDecoration="underline"
+            onClick={() => window.location.reload()}
+          >
+            refresh the window
+          </Link>{" "}
+          and try again, to see if that helps.
+        </div>
+      ),
+    })
+  }
+
+  return (
+    <Box fontSize="1.5em">
+      <Box my={5}>
+        <Text color="red.500" fontWeight={700}>
+          I am
+        </Text>
+
+        <Text as="span" fontWeight="bold">
+          {name}
+        </Text>
+        <Text as="span" ml={1} color="gray.500">
+          ({email})
+        </Text>
+      </Box>
+
+      <Box my={8}>
+        <Text color="red.500" fontWeight={700}>
+          I am attending {isOnlyOneMeeting ? "" : "(choose one)"}
+        </Text>
+
+        <RadioGroup onChange={setMeetingId} value={meetingId}>
+          {meetings.map((meeting) => (
+            <Box my={2} key={meeting.id}>
+              <Radio size="lg" value={meeting.id} bg="gray.100" display="block">
+                <Text as="span" fontSize="1.25em" fontWeight="bold">
+                  {meeting.fields.Group}
+                </Text>
+                <Text as="span" fontSize="1.25em" ml="0.5em">
+                  {/* TODO: sup with this date?? (treated as UTC?) */}
+                  {new Date(meeting.fields.Date).toLocaleDateString()}
+                </Text>
+              </Radio>
+            </Box>
+          ))}
+        </RadioGroup>
+
+        <Button
+          size="lg"
+          fontSize="1em"
+          my={10}
+          isDisabled={!meetingId || isUpdating}
+          onClick={async () => {
+            try {
+              setIsUpdating(true)
+              const fields = {
+                Meeting: [meetingId as string],
+                Attendee: email,
+              }
+              await createRecords([{ fields }])
+              displaySuccessToast()
+            } catch (e) {
+              console.error(e)
+              displayErrorToast(e)
+            } finally {
+              setIsUpdating(false)
+            }
+          }}
+        >
+          Sign in!
+          {isUpdating && <Spinner ml={2} />}
+        </Button>
+      </Box>
+    </Box>
+  )
+}
+
+export default SignInPage

--- a/pages/sign-in.tsx
+++ b/pages/sign-in.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import React, { useState } from "react"
 import {
   Text,
   Box,
@@ -17,6 +17,7 @@ import { Layout } from "../components/Layout"
 import { useAirtableRecords, useAirtableRecordCreate } from "../lib/hooks"
 import { useSession } from "next-auth/client"
 import { MeetingFields } from "../schemas/meeting"
+import { PII } from "../lib/blurred-pii"
 
 const prettyDate = (date: Date) => {
   return format(date, "eee, PPP")
@@ -119,10 +120,10 @@ const SignInForm: React.FC<SignInFormProps> = (props) => {
         </Text>
 
         <Text as="span" fontWeight="bold">
-          {name}
+          <PII blurAmount={15}>{name}</PII>
         </Text>
         <Text as="span" ml={1} color="gray.500">
-          ({email})
+          (<PII blurAmount={15}>{email}</PII>)
         </Text>
       </Box>
 

--- a/schemas/meeting.tsx
+++ b/schemas/meeting.tsx
@@ -1,0 +1,10 @@
+export interface MeetingFields {
+  /** Derived: group + formatted date */
+  Name: string
+
+  /** The group or pod name */
+  Group: string
+
+  /** The date of the meeting in YYYY-MM-DD */
+  Date: string
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4807,6 +4807,11 @@ data-uri-to-buffer@3.0.0:
   dependencies:
     buffer-from "^1.1.1"
 
+date-fns@^2.22.1:
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
+  integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
+
 debounce@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"


### PR DESCRIPTION
- use new simpler tables from Airtable for meeting and attendance management
- streamline the sign-in process
- for the first time, includes a hook/api for Airtable record _creation_

<img width=600 src="https://user-images.githubusercontent.com/140521/120880929-6630a980-c59b-11eb-8f50-9b477740ccca.gif" title="one meetings">

Above shows the typical happy path of one scheduled meeting on a given day. It will be automatically be selected, so sign-in is a one-click process.

If there is more than one meeting, user will have to select:

<img width=600 src="https://user-images.githubusercontent.com/140521/120880949-98daa200-c59b-11eb-85d7-b5c5dc8c008a.png" title="multiple meetings">